### PR TITLE
Async Code V0 (#26324)

### DIFF
--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/BufferManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/BufferManager.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import io.airbyte.integrations.destination.buffered_stream_consumer.RecordSizeEstimator;
+import io.airbyte.integrations.destination_async.MemoryBoundedLinkedBlockingQueue.MemoryItem;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+
+@Slf4j
+public class BufferManager {
+
+  public static final long TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES = (long) (Runtime.getRuntime().maxMemory() * 0.8);
+  public static final long BLOCK_SIZE_BYTES = 10 * 1024 * 1024;
+  public static final long INITIAL_QUEUE_SIZE_BYTES = BLOCK_SIZE_BYTES;
+  public static final long MAX_CONCURRENT_QUEUES = 10L;
+  public static final long QUEUE_FLUSH_THRESHOLD = 10 * 1024 * 1024; // 10MB
+
+  private final ConcurrentMap<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> buffers;
+  private final BufferManagerEnqueue bufferManagerEnqueue;
+  private final BufferManagerDequeue bufferManagerDequeue;
+  private final GlobalMemoryManager memoryManager;
+  private final ScheduledExecutorService debugLoop = Executors.newSingleThreadScheduledExecutor();
+
+  public BufferManager() {
+    memoryManager = new GlobalMemoryManager(TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES);
+    buffers = new ConcurrentHashMap<>();
+    bufferManagerEnqueue = new BufferManagerEnqueue(memoryManager, buffers);
+    bufferManagerDequeue = new BufferManagerDequeue(memoryManager, buffers);
+    debugLoop.scheduleAtFixedRate(this::printQueueInfo, 0, 10, TimeUnit.SECONDS);
+  }
+
+  public BufferManagerEnqueue getBufferManagerEnqueue() {
+    return bufferManagerEnqueue;
+  }
+
+  public BufferManagerDequeue getBufferManagerDequeue() {
+    return bufferManagerDequeue;
+  }
+
+  /**
+   * Closing a queue will flush all items from it. For this reason, this method needs to be called
+   * after {@link FlushWorkers#close()}. This allows the upload workers to make sure all items in the
+   * queue has been flushed.
+   */
+  public void close() throws Exception {
+    debugLoop.shutdownNow();
+    log.info("Buffers cleared..");
+  }
+
+  private void printQueueInfo() {
+    final var queueInfo = new StringBuilder().append("QUEUE INFO").append(System.lineSeparator());
+
+    queueInfo
+        .append(String.format("  Global Mem Manager -- max: %s, allocated: %s",
+            FileUtils.byteCountToDisplaySize(memoryManager.getMaxMemoryBytes()),
+            FileUtils.byteCountToDisplaySize(memoryManager.getCurrentMemoryBytes())))
+        .append(System.lineSeparator());
+
+    for (final var entry : buffers.entrySet()) {
+      final var queue = entry.getValue();
+      queueInfo.append(
+          String.format("  Queue name: %s, num records: %d, num bytes: %s",
+              entry.getKey().getName(), queue.size(), FileUtils.byteCountToDisplaySize(queue.getCurrentMemoryUsage())))
+          .append(System.lineSeparator());
+    }
+    log.info(queueInfo.toString());
+  }
+
+  public static class BufferManagerEnqueue {
+
+    private final RecordSizeEstimator recordSizeEstimator;
+
+    private final GlobalMemoryManager memoryManager;
+    private final ConcurrentMap<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> buffers;
+
+    public BufferManagerEnqueue(final GlobalMemoryManager memoryManager,
+                                final ConcurrentMap<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> buffers) {
+      this.memoryManager = memoryManager;
+      this.buffers = buffers;
+      recordSizeEstimator = new RecordSizeEstimator();
+    }
+
+    public void addRecord(final StreamDescriptor streamDescriptor, final AirbyteMessage message) {
+      if (!buffers.containsKey(streamDescriptor)) {
+        buffers.put(streamDescriptor, new MemoryBoundedLinkedBlockingQueue<>(INITIAL_QUEUE_SIZE_BYTES));
+      }
+
+      // todo (cgardens) - handle estimating state message size.
+      final long messageSize = message.getType() == AirbyteMessage.Type.RECORD ? recordSizeEstimator.getEstimatedByteSize(message.getRecord()) : 1024;
+
+      final var queue = buffers.get(streamDescriptor);
+      var addedToQueue = queue.offer(message, messageSize);
+
+      // todo (cgardens) - what if the record being added is bigger than the bock size?
+      // if failed, try to increase memory and add to queue.
+      while (!addedToQueue) {
+        final var freeMem = memoryManager.requestMemory();
+        if (freeMem > 0) {
+          queue.setMaxMemoryUsage(queue.getMaxMemoryUsage() + freeMem);
+        }
+        addedToQueue = queue.offer(message, messageSize);
+      }
+    }
+
+  }
+
+  // todo (cgardens) - make all the metadata methods more efficient.
+  static class BufferManagerDequeue {
+
+    private final GlobalMemoryManager memoryManager;
+    private final ConcurrentMap<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> buffers;
+    private final ConcurrentMap<StreamDescriptor, ReentrantLock> bufferLocks;
+
+    public BufferManagerDequeue(final GlobalMemoryManager memoryManager,
+                                final ConcurrentMap<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> buffers) {
+      this.memoryManager = memoryManager;
+      this.buffers = buffers;
+      bufferLocks = new ConcurrentHashMap<>();
+    }
+
+    public Map<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> getBuffers() {
+      return new HashMap<>(buffers);
+    }
+
+    private MemoryBoundedLinkedBlockingQueue<AirbyteMessage> getBuffer(final StreamDescriptor streamDescriptor) {
+      return buffers.get(streamDescriptor);
+    }
+
+    public long getTotalGlobalQueueSizeBytes() {
+      return buffers.values().stream().map(MemoryBoundedLinkedBlockingQueue::getCurrentMemoryUsage).mapToLong(Long::longValue).sum();
+    }
+
+    public long getQueueSizeInRecords(final StreamDescriptor streamDescriptor) {
+      return getBuffer(streamDescriptor).size();
+    }
+
+    public long getQueueSizeBytes(final StreamDescriptor streamDescriptor) {
+      return getBuffer(streamDescriptor).getCurrentMemoryUsage();
+    }
+
+    public Optional<Instant> getTimeOfLastRecord(final StreamDescriptor streamDescriptor) {
+      return getBuffer(streamDescriptor).getTimeOfLastMessage();
+    }
+
+    public Batch take(final StreamDescriptor streamDescriptor, final long bytesToRead) {
+      final var queue = buffers.get(streamDescriptor);
+
+      if (!bufferLocks.containsKey(streamDescriptor)) {
+        bufferLocks.put(streamDescriptor, new ReentrantLock());
+      }
+
+      bufferLocks.get(streamDescriptor).lock();
+      try {
+        final AtomicLong bytesRead = new AtomicLong();
+
+        final var s = Stream.generate(() -> {
+          try {
+            return queue.poll(5, TimeUnit.MILLISECONDS);
+          } catch (final InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        }).takeWhile(memoryItem -> {
+          // if no new records after waiting, the stream is done.
+          if (memoryItem == null) {
+            return false;
+          }
+
+          // otherwise pull records until we hit the memory limit.
+          final long newSize = memoryItem.size() + bytesRead.get();
+          if (newSize <= bytesToRead) {
+            bytesRead.addAndGet(memoryItem.size());
+            return true;
+          } else {
+            return false;
+          }
+        }).map(MemoryItem::item)
+            .toList()
+            .stream();
+
+        // todo (cgardens) - possible race where in between pulling records and new records going in that we
+        // reset the limit to be lower than number of bytes already in the queue. probably not a big deal.
+        queue.setMaxMemoryUsage(queue.getMaxMemoryUsage() - bytesRead.get());
+
+        return new Batch(s, bytesRead.get(), memoryManager);
+      } finally {
+        bufferLocks.get(streamDescriptor).unlock();
+      }
+    }
+
+    public static class Batch implements AutoCloseable {
+
+      private Stream<AirbyteMessage> batch;
+      private final long sizeInBytes;
+      private final GlobalMemoryManager memoryManager;
+
+      public Batch(final Stream<AirbyteMessage> batch, final long sizeInBytes, final GlobalMemoryManager memoryManager) {
+        this.batch = batch;
+        this.sizeInBytes = sizeInBytes;
+        this.memoryManager = memoryManager;
+      }
+
+      public Stream<AirbyteMessage> getData() {
+        return batch;
+      }
+
+      @Override
+      public void close() throws Exception {
+        batch = null;
+        memoryManager.free(sizeInBytes);
+      }
+
+    }
+
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/DestinationFlushFunction.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/DestinationFlushFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.util.stream.Stream;
+
+/**
+ * An interface meant to be used with {@link FlushWorkers}.
+ * <p>
+ * A destination instructs workers how to write data by specifying
+ * {@link #flush(StreamDescriptor, Stream)}. This keeps the worker abstraction generic and reusable.
+ * <p>
+ * e.g. A database destination's flush function likely involves parsing the stream into SQL
+ * statements.
+ * <p>
+ * There are 2 different destination types as of this writing:
+ * <ul>
+ * <li>1. Destinations that upload files. This includes warehouses and databases.</li>
+ * <li>2. Destinations that upload data streams. This mostly includes various Cloud storages. This
+ * will include reverse-ETL in the future</li>
+ * </ul>
+ * In both cases, the simplest way to model the incoming data is as a stream.
+ */
+public interface DestinationFlushFunction {
+
+  /**
+   * Flush a batch of data to the destination.
+   *
+   * @param decs the Airbyte stream the data stream belongs to
+   * @param stream a bounded {@link AirbyteMessage} stream ideally of
+   *        {@link #getOptimalBatchSizeBytes()} size
+   * @throws Exception
+   */
+  void flush(StreamDescriptor decs, Stream<AirbyteMessage> stream) throws Exception;
+
+  /**
+   * When invoking {@link #flush(StreamDescriptor, Stream)}, best effort attempt to invoke flush with
+   * a batch of this size. Useful for Destinations that have optimal flush batch sizes.
+   *
+   * @return the optimal batch size in bytes
+   */
+  long getOptimalBatchSizeBytes();
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/FlushWorkers.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/FlushWorkers.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static io.airbyte.integrations.destination_async.BufferManager.QUEUE_FLUSH_THRESHOLD;
+import static io.airbyte.integrations.destination_async.BufferManager.TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES;
+
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Parallel flushing of Destination data.
+ * <p>
+ * In combination with a {@link DestinationFlushFunction} and the {@link #workerPool}, this class
+ * allows for parallel data flushing.
+ * <p>
+ * Parallelising is important as it 1) minimises Destination backpressure 2) minimises the effect of
+ * IO pauses on Destination performance. The second point is particularly important since majority
+ * of Destination work is IO bound.
+ * <p>
+ * The {@link #supervisorThread} assigns work to worker threads by looping over
+ * {@link #bufferManagerDequeue} - a dequeue interface over in-memory queues of
+ * {@link AirbyteMessage}. See {@link #retrieveWork()} for assignment logic.
+ * <p>
+ * Within a worker thread, a worker best-effort reads a
+ * {@link DestinationFlushFunction#getOptimalBatchSizeBytes()} batch from the in-memory stream and
+ * calls {@link DestinationFlushFunction#flush(StreamDescriptor, Stream)} on the returned data.
+ */
+@Slf4j
+public class FlushWorkers implements AutoCloseable {
+
+  private static final long MAX_TIME_BETWEEN_REC_MINS = 5L;
+  private static final long SUPERVISOR_INITIAL_DELAY_SECS = 0L;
+  private static final long SUPERVISOR_PERIOD_SECS = 1L;
+  private static final long DEBUG_INITIAL_DELAY_SECS = 0L;
+  private static final long DEBUG_PERIOD_SECS = 10L;
+  private final ScheduledExecutorService supervisorThread = Executors.newScheduledThreadPool(1);
+  private final ExecutorService workerPool = Executors.newFixedThreadPool(5);
+  private final BufferManager.BufferManagerDequeue bufferManagerDequeue;
+  private final DestinationFlushFunction flusher;
+  private final ScheduledExecutorService debugLoop = Executors.newSingleThreadScheduledExecutor();
+
+  public FlushWorkers(final BufferManager.BufferManagerDequeue bufferManagerDequeue, final DestinationFlushFunction flushFunction) {
+    this.bufferManagerDequeue = bufferManagerDequeue;
+    flusher = flushFunction;
+  }
+
+  public void start() {
+    supervisorThread.scheduleAtFixedRate(this::retrieveWork, SUPERVISOR_INITIAL_DELAY_SECS, SUPERVISOR_PERIOD_SECS,
+        TimeUnit.SECONDS);
+    debugLoop.scheduleAtFixedRate(this::printWorkerInfo, DEBUG_INITIAL_DELAY_SECS, DEBUG_PERIOD_SECS, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public void close() throws Exception {
+    flushAll();
+
+    supervisorThread.shutdown();
+    final var supervisorShut = supervisorThread.awaitTermination(5L, TimeUnit.MINUTES);
+    log.info("Supervisor shut status: {}", supervisorShut);
+
+    log.info("Starting worker pool shutdown..");
+    workerPool.shutdown();
+    final var workersShut = workerPool.awaitTermination(5L, TimeUnit.MINUTES);
+    log.info("Workers shut status: {}", workersShut);
+  }
+
+  private void retrieveWork() {
+    // todo (cgardens) - i'm not convinced this makes sense. as we get close to the limit, we should
+    // flush more eagerly, but "flush all" is never a particularly useful thing in this world.
+    // if the total size is > n, flush all buffers
+    if (bufferManagerDequeue.getTotalGlobalQueueSizeBytes() > TOTAL_QUEUES_MAX_SIZE_LIMIT_BYTES) {
+      flushAll();
+    }
+
+    // todo (cgardens) - build a score to prioritize which queue to flush next. e.g. if a queue is very
+    // large, flush it first. if a queue has not been flushed in a while, flush it next.
+    // otherwise, if each individual stream has crossed a specific threshold, flush
+    for (final Map.Entry<StreamDescriptor, MemoryBoundedLinkedBlockingQueue<AirbyteMessage>> entry : bufferManagerDequeue.getBuffers().entrySet()) {
+      final var stream = entry.getKey();
+      final var exceedSize = bufferManagerDequeue.getQueueSizeBytes(stream) >= QUEUE_FLUSH_THRESHOLD;
+      final var tooLongSinceLastRecord = bufferManagerDequeue.getTimeOfLastRecord(stream)
+          .map(time -> time.isBefore(Instant.now().minus(MAX_TIME_BETWEEN_REC_MINS, ChronoUnit.MINUTES)))
+          .orElse(false);
+      if (exceedSize || tooLongSinceLastRecord) {
+        flush(stream);
+      }
+    }
+  }
+
+  private void printWorkerInfo() {
+    final var workerInfo = new StringBuilder().append("WORKER INFO").append(System.lineSeparator());
+
+    final ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) workerPool;
+
+    final int queueSize = threadPoolExecutor.getQueue().size();
+    final int activeCount = threadPoolExecutor.getActiveCount();
+
+    workerInfo.append(String.format("  Pool queue size: %d, Active threads: %d", queueSize, activeCount));
+    log.info(workerInfo.toString());
+
+  }
+
+  private void flushAll() {
+    log.info("Flushing all buffers..");
+    for (final StreamDescriptor desc : bufferManagerDequeue.getBuffers().keySet()) {
+      flush(desc);
+    }
+  }
+
+  private void flush(final StreamDescriptor desc) {
+    workerPool.submit(() -> {
+      log.info("Worker picked up work..");
+      try {
+        log.info("Attempting to read from queue {}. Current queue size: {}", desc, bufferManagerDequeue.getQueueSizeInRecords(desc));
+
+        try (final var batch = bufferManagerDequeue.take(desc, flusher.getOptimalBatchSizeBytes())) {
+          flusher.flush(desc, batch.getData());
+        }
+
+        log.info("Worker finished flushing. Current queue size: {}", bufferManagerDequeue.getQueueSizeInRecords(desc));
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/GlobalMemoryManager.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/GlobalMemoryManager.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GlobalMemoryManager {
+
+  private static final long BLOCK_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+  private final long maxMemoryBytes;
+
+  private final AtomicLong currentMemoryBytes = new AtomicLong(0);
+
+  public GlobalMemoryManager(final long maxMemoryBytes) {
+    this.maxMemoryBytes = maxMemoryBytes;
+  }
+
+  public long getMaxMemoryBytes() {
+    return maxMemoryBytes;
+  }
+
+  public long getCurrentMemoryBytes() {
+    return currentMemoryBytes.get();
+  }
+
+  public synchronized long requestMemory() {
+    if (currentMemoryBytes.get() >= maxMemoryBytes) {
+      return 0L;
+    }
+
+    final var freeMem = maxMemoryBytes - currentMemoryBytes.get();
+    // Never allocate more than free memory size.
+    final var toAllocateBytes = Math.min(freeMem, BLOCK_SIZE_BYTES);
+    currentMemoryBytes.addAndGet(toAllocateBytes);
+
+    return toAllocateBytes;
+  }
+
+  public void free(final long bytes) {
+    currentMemoryBytes.addAndGet(-bytes);
+
+    if (currentMemoryBytes.get() < 0) {
+      log.warn("Freed more memory than allocated. This should never happen. Please report this bug.");
+    }
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/MemoryBoundedLinkedBlockingQueue.java
+++ b/airbyte-integrations/bases/base-java/src/main/java/io/airbyte/integrations/destination_async/MemoryBoundedLinkedBlockingQueue.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MemoryBoundedLinkedBlockingQueue<E> extends LinkedBlockingQueue<MemoryBoundedLinkedBlockingQueue.MemoryItem<E>> {
+
+  private final AtomicLong currentMemoryUsage;
+  private final AtomicLong maxMemoryUsage;
+
+  private final AtomicReference<Instant> timeOfLastMessage;
+
+  public MemoryBoundedLinkedBlockingQueue(final long maxMemoryUsage) {
+    currentMemoryUsage = new AtomicLong(0);
+    this.maxMemoryUsage = new AtomicLong(maxMemoryUsage);
+    timeOfLastMessage = new AtomicReference(null);
+  }
+
+  public long getCurrentMemoryUsage() {
+    return currentMemoryUsage.get();
+  }
+
+  public long getMaxMemoryUsage() {
+    return maxMemoryUsage.get();
+  }
+
+  public void setMaxMemoryUsage(final long maxMemoryUsage) {
+    this.maxMemoryUsage.set(maxMemoryUsage);
+  }
+
+  public Optional<Instant> getTimeOfLastMessage() {
+    return Optional.ofNullable(timeOfLastMessage.get());
+  }
+
+  public boolean offer(final E e, final long itemSizeInBytes) {
+    final long newMemoryUsage = currentMemoryUsage.addAndGet(itemSizeInBytes);
+    if (newMemoryUsage <= maxMemoryUsage.get()) {
+      final boolean success = super.offer(new MemoryItem<>(e, itemSizeInBytes));
+      if (!success) {
+        currentMemoryUsage.addAndGet(-itemSizeInBytes);
+      } else {
+        // it succeeded!
+        timeOfLastMessage.set(Instant.now());
+      }
+      log.debug("offer status: {}", success);
+      return success;
+    } else {
+      currentMemoryUsage.addAndGet(-itemSizeInBytes);
+      log.debug("offer failed");
+      return false;
+    }
+  }
+
+  @Override
+  public MemoryBoundedLinkedBlockingQueue.MemoryItem<E> take() throws InterruptedException {
+    final MemoryItem<E> memoryItem = super.take();
+    if (memoryItem != null) {
+      currentMemoryUsage.addAndGet(-memoryItem.size());
+      return memoryItem;
+    }
+    return null;
+  }
+
+  @Override
+  public MemoryBoundedLinkedBlockingQueue.MemoryItem<E> poll() {
+    final MemoryItem<E> memoryItem = super.poll();
+    if (memoryItem != null) {
+      currentMemoryUsage.addAndGet(-memoryItem.size());
+      return memoryItem;
+    }
+    return null;
+  }
+
+  public record MemoryItem<E> (E item, long size) {}
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/BufferManagerDequeueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/BufferManagerDequeueTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.integrations.destination_async.BufferManager.BufferManagerDequeue;
+import io.airbyte.integrations.destination_async.BufferManager.BufferManagerDequeue.Batch;
+import io.airbyte.integrations.destination_async.BufferManager.BufferManagerEnqueue;
+import io.airbyte.protocol.models.v0.AirbyteMessage;
+import io.airbyte.protocol.models.v0.AirbyteMessage.Type;
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage;
+import io.airbyte.protocol.models.v0.StreamDescriptor;
+import org.junit.jupiter.api.Test;
+
+public class BufferManagerDequeueTest {
+
+  private static final String STREAM_NAME = "stream1";
+  private static final StreamDescriptor STREAM_DESC = new StreamDescriptor().withName(STREAM_NAME);
+  private static final String RECORD = "abc";
+  private static final AirbyteMessage RECORD_MSG = new AirbyteMessage()
+      .withType(Type.RECORD)
+      .withRecord(new AirbyteRecordMessage()
+          .withStream(STREAM_NAME)
+          .withData(Jsons.jsonNode(RECORD)));
+
+  @Test
+  void testReadFromBatch() {
+    final BufferManager bufferManager = new BufferManager();
+    final BufferManagerEnqueue enqueue = bufferManager.getBufferManagerEnqueue();
+    final BufferManagerDequeue dequeue = bufferManager.getBufferManagerDequeue();
+
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG);
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG);
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG);
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG);
+
+    // total size of records is 80, so we expect 50 to get us 2 records (prefer to under-pull records
+    // than over-pull).
+    try (final Batch take = dequeue.take(STREAM_DESC, 50)) {
+      assertEquals(2, take.getData().toList().size());
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  void testReadFromBatchFewerRecordsThanSizeLimit() {
+    final BufferManager bufferManager = new BufferManager();
+    final BufferManagerEnqueue enqueue = bufferManager.getBufferManagerEnqueue();
+    final BufferManagerDequeue dequeue = bufferManager.getBufferManagerDequeue();
+
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG);
+    enqueue.addRecord(STREAM_DESC, RECORD_MSG);
+
+    try (final Batch take = dequeue.take(STREAM_DESC, Long.MAX_VALUE)) {
+      assertEquals(2, take.getData().toList().size());
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/BufferManagerEnqueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/BufferManagerEnqueueTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import org.junit.Test;
+
+public class BufferManagerEnqueueTest {
+
+  @Test
+  void OfferAndRetrieve() {
+
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/GlobalMemoryManagerTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/GlobalMemoryManagerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class GlobalMemoryManagerTest {
+
+  private static final long BYTES_10_MB = 10 * 1024 * 1024;
+  private static final long BYTES_35_MB = 35 * 1024 * 1024;
+  private static final long BYTES_5_MB = 5 * 1024 * 1024;
+
+  @Test
+  void test() {
+    final GlobalMemoryManager mgr = new GlobalMemoryManager(BYTES_35_MB);
+
+    assertEquals(BYTES_10_MB, mgr.requestMemory());
+    assertEquals(BYTES_10_MB, mgr.requestMemory());
+    assertEquals(BYTES_10_MB, mgr.requestMemory());
+    assertEquals(BYTES_5_MB, mgr.requestMemory());
+    assertEquals(0, mgr.requestMemory());
+
+    mgr.free(BYTES_10_MB);
+
+    assertEquals(BYTES_10_MB, mgr.requestMemory());
+  }
+
+}

--- a/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/MemoryBoundedLinkedBlockingQueueTest.java
+++ b/airbyte-integrations/bases/base-java/src/test/java/io/airbyte/integrations/destination_async/MemoryBoundedLinkedBlockingQueueTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination_async;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class MemoryBoundedLinkedBlockingQueueTest {
+
+  @Test
+  void offerAndTakeShouldReturn() throws InterruptedException {
+    final MemoryBoundedLinkedBlockingQueue<String> queue = new MemoryBoundedLinkedBlockingQueue<>(1024);
+
+    queue.offer("abc", 6);
+
+    var item = queue.take();
+
+    assertEquals("abc", item.item());
+  }
+
+  @Test
+  void offerAndToStreamShouldReturn() throws InterruptedException {
+    final MemoryBoundedLinkedBlockingQueue<String> queue = new MemoryBoundedLinkedBlockingQueue<>(1024);
+
+    queue.offer("abc", 6);
+    queue.offer("DEF", 6);
+
+    System.out.println(queue.size());
+    queue.stream().forEach(stringMemoryItem -> System.out.println(stringMemoryItem.item()));
+    System.out.println(queue.size());
+  }
+
+  @Test
+  void test() throws InterruptedException {
+    final MemoryBoundedLinkedBlockingQueue<String> queue = new MemoryBoundedLinkedBlockingQueue<>(1024);
+
+    assertEquals(0, queue.getCurrentMemoryUsage());
+    assertNull(queue.getTimeOfLastMessage().orElse(null));
+
+    queue.offer("abc", 6);
+    queue.offer("abc", 6);
+    queue.offer("abc", 6);
+
+    assertEquals(18, queue.getCurrentMemoryUsage());
+    assertNotNull(queue.getTimeOfLastMessage().orElse(null));
+
+    queue.take();
+    queue.take();
+    queue.take();
+
+    assertEquals(0, queue.getCurrentMemoryUsage());
+    assertNotNull(queue.getTimeOfLastMessage().orElse(null));
+  }
+
+  @Test
+  void testBlocksOnFullMemory() throws InterruptedException {
+    final MemoryBoundedLinkedBlockingQueue<String> queue = new MemoryBoundedLinkedBlockingQueue<>(10);
+    assertTrue(queue.offer("abc", 6));
+    assertFalse(queue.offer("abc", 6));
+
+    assertNotNull(queue.poll(1, TimeUnit.NANOSECONDS));
+    assertNull(queue.poll(1, TimeUnit.NANOSECONDS));
+
+  }
+
+}

--- a/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-mysql/src/test/java/io/airbyte/integrations/source/mysql/MySqlSourceOperationsTest.java
@@ -302,5 +302,5 @@ public class MySqlSourceOperationsTest {
       throw new RuntimeException(e);
     }
   }
-  
+
 }

--- a/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
+++ b/airbyte-integrations/connectors/source-postgres/src/main/java/io/airbyte/integrations/source/postgres/PostgresSourceOperations.java
@@ -357,7 +357,6 @@ public class PostgresSourceOperations extends AbstractJdbcCompatibleSourceOperat
     node.set(columnName, arrayNode);
   }
 
-
   private void putDoubleArray(final ObjectNode node, final String columnName, final ResultSet resultSet, final int colIndex) throws SQLException {
     final ArrayNode arrayNode = Jsons.arrayNode();
     final ResultSet arrayResultSet = resultSet.getArray(colIndex).getResultSet();

--- a/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test-integration/java/io/airbyte/integrations/io/airbyte/integration_tests/sources/AbstractPostgresSourceDatatypeTest.java
@@ -294,9 +294,8 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
             .build());
 
     /*
-     * Verify NUMERIC/DECIMAL Datatypes has
-     *  - the default precision of 131089 (See PostgresConverter)
-     *  - unspecified scale - any decimal value is preserved
+     * Verify NUMERIC/DECIMAL Datatypes has - the default precision of 131089 (See PostgresConverter) -
+     * unspecified scale - any decimal value is preserved
      */
     addDataTypeTestData(
         TestDataHolder.builder()
@@ -776,9 +775,8 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
 
     for (final String type : Set.of("numeric", "decimal")) {
       /*
-       * Verify NUMERIC[]/DECIMAL[] Datatypes has
-       *  - the default precision of 131089 (See PostgresConverter)
-       *  - unspecified scale - any decimal value is preserved
+       * Verify NUMERIC[]/DECIMAL[] Datatypes has - the default precision of 131089 (See
+       * PostgresConverter) - unspecified scale - any decimal value is preserved
        */
       addDataTypeTestData(
           TestDataHolder.builder()
@@ -792,17 +790,17 @@ public abstract class AbstractPostgresSourceDatatypeTest extends AbstractSourceD
               .addExpectedValues("[131070.23,231072.476596593]")
               .build());
       /*
-       * Verify NUMERIC(`anyNumber`)[]/DECIMAL(`anyNumber`)[] Datatypes has
-       * default scale of 0 if the Precision is set
+       * Verify NUMERIC(`anyNumber`)[]/DECIMAL(`anyNumber`)[] Datatypes has default scale of 0 if the
+       * Precision is set
        */
       addDataTypeTestData(
           TestDataHolder.builder()
               .sourceType(String.format("%s_array", type))
               .fullSourceDataType(String.format("%s(20)[]", type.toUpperCase()))
               .airbyteType(JsonSchemaType.builder(JsonSchemaPrimitive.ARRAY)
-                               .withItems(JsonSchemaType.builder(JsonSchemaPrimitive.NUMBER)
-                                              .build())
-                               .build())
+                  .withItems(JsonSchemaType.builder(JsonSchemaPrimitive.NUMBER)
+                      .build())
+                  .build())
               .addInsertValues("'{131070,231072}'")
               .addExpectedValues("[131070,231072]")
               .build());

--- a/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-postgres/src/test/java/io/airbyte/integrations/source/postgres/PostgresSourceOperationsTest.java
@@ -102,9 +102,9 @@ class PostgresSourceOperationsTest {
       final long cursorValue = i * 10;
       jsonNode.put(cursorColumn, cursorValue);
       final String insertQuery = String.format("INSERT INTO %s VALUES (%s, %s);",
-                                               tableName,
-                                               i,
-                                               cursorValue);
+          tableName,
+          i,
+          cursorValue);
       executeQuery(insertQuery);
       expectedRecords.add(jsonNode);
     }
@@ -191,4 +191,5 @@ class PostgresSourceOperationsTest {
       throw new RuntimeException(e);
     }
   }
+
 }


### PR DESCRIPTION
Split out the smallest set of reasonable changes from #26086 .

My goal was to split out the interface, as well as show how the interface it's meant to be used.

Follow up PRs:
- Split out classes from BufferManager and add more tests there.
- Add in the AsyncConsumer with tests.
- Add in the StagingConsumer factory.

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests#pull-request-title-convention)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:testScaffoldTemplates` then checking in your changes
- Documentation which references the generator is updated as needed

</details>
